### PR TITLE
calculate the next run if the schedule is active

### DIFF
--- a/yawn/settings/test.py
+++ b/yawn/settings/test.py
@@ -1,3 +1,11 @@
 from .debug import *  # NOQA
 
 ALLOWED_HOSTS = ['testserver']
+
+# test raven integration:
+
+# INSTALLED_APPS += ['raven.contrib.django']
+#
+# RAVEN_CONFIG = {
+#     'dsn': os.environ.get('SENTRY_DSN'),
+# }

--- a/yawn/workflow/models.py
+++ b/yawn/workflow/models.py
@@ -1,8 +1,10 @@
 from django.db import models
 from django.contrib.postgres import fields
 from django.db.models import functions
+from django.utils import timezone
 
 from yawn.utilities import cron
+from yawn.utilities.cron import Crontab
 
 
 class WorkflowName(models.Model):
@@ -35,6 +37,15 @@ class Workflow(models.Model):
 
     # parameters
     parameters = fields.JSONField(default=dict)
+
+    def save(self, **kwargs):
+        if self.schedule_active:
+            if not self.next_run:
+                # this call uses the server time instead of the db time...
+                self.next_run = Crontab(self.schedule).next_run(timezone.now())
+        else:
+            self.next_run = None
+        super().save(**kwargs)
 
     @classmethod
     def first_ready(cls):

--- a/yawn/workflow/serializers.py
+++ b/yawn/workflow/serializers.py
@@ -112,7 +112,7 @@ def unchanged(current_workflow, new_data):
 
     This is ugly; suggestions would be appreciated...
     """
-    ignore = ('id', 'name', 'version', 'schedule_active')
+    ignore = ('id', 'name', 'version', 'schedule_active', 'next_run', 'parameters')
     if not compare_fields(current_workflow, new_data, ignore):
         return False
 
@@ -122,7 +122,7 @@ def unchanged(current_workflow, new_data):
         return False
 
     for current_task, new_task in zip(current_tasks, new_tasks):
-        ignore = ('id', 'upstream', 'workflow', 'next_run', 'parameters')
+        ignore = ('id', 'upstream', 'workflow')
         if not compare_fields(current_task, new_task, ignore):
             return False
 

--- a/yawn/workflow/serializers.py
+++ b/yawn/workflow/serializers.py
@@ -122,7 +122,7 @@ def unchanged(current_workflow, new_data):
         return False
 
     for current_task, new_task in zip(current_tasks, new_tasks):
-        ignore = ('id', 'upstream', 'workflow')
+        ignore = ('id', 'upstream', 'workflow', 'next_run', 'parameters')
         if not compare_fields(current_task, new_task, ignore):
             return False
 

--- a/yawn/workflow/serializers.py
+++ b/yawn/workflow/serializers.py
@@ -166,6 +166,7 @@ class RunSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         workflow = Workflow.objects.get(id=validated_data['workflow_id'])
-        run = workflow.submit_run(validated_data['parameters'])
+        parameters = validated_data.get('parameters')
+        run = workflow.submit_run(parameters)
         run.refresh_from_db()  # load submitted_time...
         return run

--- a/yawn/workflow/tests/test_models.py
+++ b/yawn/workflow/tests/test_models.py
@@ -7,6 +7,7 @@ A, B, C, D succeed -> Succeeded
 A, B failed, C, D upstream_failed -> Failed
 """
 import datetime
+from unittest import mock
 
 from django.utils import timezone
 
@@ -34,6 +35,19 @@ def test_first_ready():
 
     workflow = Workflow.first_ready()
     assert workflow.id == ready_workflow.id
+
+
+@mock.patch('yawn.workflow.models.Crontab')
+def test_next_run(mock_cron):
+    next_run = timezone.datetime(2011, 1, 1)
+    mock_cron().next_run.return_value = next_run
+
+    name = WorkflowName.objects.create(name='workflow1')
+    workflow = Workflow.objects.create(
+        name=name, version=2, schedule_active=True,
+        schedule='*'
+    )
+    assert workflow.next_run == next_run
 
 
 def test_new_version():

--- a/yawn/workflow/tests/test_views.py
+++ b/yawn/workflow/tests/test_views.py
@@ -92,16 +92,25 @@ def test_get_run(client, run):
 
 
 def test_post_run(client, run):
+    """create a new run of the workflow"""
     url = '/api/runs/'
     workflow = run.workflow
     data = {'workflow_id': workflow.id, 'parameters': {'A': '1', 'B': 'false'}}
     response = client.post(url, data)
     assert response.status_code == 201, response.data
-    assert response.data['id'] > run.id
+    assert response.data['id'] == run.id + 1
     assert response.data['status'] == run.RUNNING
     merged_parameters = workflow.parameters.copy()
     merged_parameters.update(data['parameters'])
     assert response.data['parameters'] == merged_parameters
+
+    # without parameters
+    data = {'workflow_id': workflow.id}
+    response = client.post(url, data)
+    assert response.status_code == 201, response.data
+    assert response.data['id'] == run.id + 2
+    assert response.data['status'] == run.RUNNING
+    assert response.data['parameters'] == workflow.parameters
 
 
 def test_patch_run(client, run):

--- a/yawn/workflow/tests/test_views.py
+++ b/yawn/workflow/tests/test_views.py
@@ -13,7 +13,7 @@ def test_create_workflow(client, data):
     response = client.post('/api/workflows/', data)
     assert response.status_code == 201
     assert response.data['name'] == data['name']
-    assert response.data['next_run'] > timezone.now() - timezone.timedelta(minutes=1)
+    assert response.data['next_run'] is not None
     assert response.data['schedule'] == data['schedule']
     assert response.data['schedule_active'] == data['schedule_active']
     assert response.data['parameters'] == data['parameters']

--- a/yawn/workflow/tests/test_views.py
+++ b/yawn/workflow/tests/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from yawn.workflow.models import WorkflowName
@@ -12,7 +13,7 @@ def test_create_workflow(client, data):
     response = client.post('/api/workflows/', data)
     assert response.status_code == 201
     assert response.data['name'] == data['name']
-    assert response.data['next_run'] is None
+    assert response.data['next_run'] > timezone.now() - timezone.timedelta(minutes=1)
     assert response.data['schedule'] == data['schedule']
     assert response.data['schedule_active'] == data['schedule_active']
     assert response.data['parameters'] == data['parameters']

--- a/yawn/workflow/tests/test_views.py
+++ b/yawn/workflow/tests/test_views.py
@@ -1,6 +1,5 @@
 import pytest
 
-from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from yawn.workflow.models import WorkflowName


### PR DESCRIPTION
- create run without parameters
- don't make a new workflow if only the parameters have changed